### PR TITLE
make sure to have pass installed

### DIFF
--- a/docs/apache-airflow/howto/docker-compose/index.rst
+++ b/docs/apache-airflow/howto/docker-compose/index.rst
@@ -147,6 +147,12 @@ On **all operating systems**, you need to run database migrations and create the
 
     docker compose up airflow-init
 
+make sure that you have pass installed
+
+.. code-block:: bash
+
+    sudo apt install pass
+
 After initialization is complete, you should see a message like this:
 
 .. parsed-literal::


### PR DESCRIPTION
when i was trying to follow the tutorial to init a airflow environment. I always got this error during `docker-compose up airflow-init`

Cannot autolaunch D-Bus without X11 $DISPLAY

As I found out here 
https://github.com/docker/compose-cli/issues/1656
the problem occurs since did not have `pass` installed on my ubuntu wsl.

Probably it is not the best place to put it. But I would put it somewhere in the docs where it is easy to find for users like me, that just want to do a painless tutorial of airflow